### PR TITLE
chore: add pre-merge check

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 .eslintrc.js
+.github

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,0 +1,29 @@
+name: Pre-merge
+
+# Controls when the action will run.
+on:
+  pull_request:
+    branches:
+      - main
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node: [ 14 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules
 dist_electron
 .eslintrc.js
+.github


### PR DESCRIPTION
Add a pre-merge check that runs

```
npm run lint
```

This ensures all work submitted is compliant with the projects settings.